### PR TITLE
Enforce a more strict validation of URIs in the JSON schema.

### DIFF
--- a/data.schema.json
+++ b/data.schema.json
@@ -15,6 +15,12 @@
 			}
 		}
 	},
+	"definitions": {
+		"saneUrl": {
+			"format": "uri",
+			"pattern": "^https?://"
+		}
+	},
 	"$defs": {
 		"releaseNoteMetaObject": {
 			"type": "object",
@@ -27,8 +33,8 @@
 					"type": "string",
 					"description": "The name of the entry."
 				},
-				"veggieLike": {
-					"type": "boolean",
+				"url": {
+					"$ref": "#/definitions/saneUrl",
 					"description": "The URL where release notes can be found for the entry."
 				}
 			}


### PR DESCRIPTION
Also the old one was broken? How was this not noticed?